### PR TITLE
Add helper methods for strongly typed retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# This file is used for Git repositories to specify intentionally untracked files that Git should ignore. 
+# This file is used for Git repositories to specify intentionally untracked files that Git should ignore.
 # If you are not using git, you can delete this file. For more information see: https://git-scm.com/docs/gitignore
 # For useful gitignore templates see: https://github.com/github/gitignore
 
@@ -23,6 +23,8 @@ yarn-error.log*
 
 # Dependency directories
 node_modules/
+# since yarn.lock is checked in
+package-lock.json
 
 # Eslint cache
 .eslintcache

--- a/force-app/main/default/classes/JSONPath.cls
+++ b/force-app/main/default/classes/JSONPath.cls
@@ -7,6 +7,26 @@ public class JSONPath {
         this.data = JSON.deserializeUntyped(rawJson);
     }
 
+    public Decimal getNumber(String path) {
+        return (Decimal) this.get(path);
+    }
+
+    public Date getDate(String path) {
+        return Date.valueOf(this.getString(path));
+    }
+
+    public Datetime getDatetime(String path) {
+        return Datetime.valueOf(this.getString(path));
+    }
+
+    public Object getDeserializedObject(String path, Type typeToDeserialize) {
+        return JSON.deserialize(JSON.serialize(this.get(path)), typeToDeserialize);
+    }
+
+    public String getString(String path) {
+        return (String) this.get(path);
+    }
+
     public Object get(String path) {
         try {
             Object o = this.get(path.removeStart('$'), this.data);

--- a/force-app/main/default/classes/JSONPathTest.cls
+++ b/force-app/main/default/classes/JSONPathTest.cls
@@ -107,4 +107,21 @@ private class JSONPathTest {
             'Incorrect result for "avg".'
         );
     }
+
+    @IsTest
+    static void usesHelperFunctionsToReturnStrongTypes() {
+        String exampleJson = '{ "number": 1, "aDate": "2020-01-01", "aDatetime": "2020-01-01 00:00:000Z", "text": "hi", "exampleObject": { "myProp": 1 } }';
+
+        JSONPath path = new JSONPath(exampleJson);
+
+        System.assertEquals(1, path.getNumber('$.number'));
+        System.assertEquals(Date.newInstance(2020, 1, 1), path.getDate('$.aDate'));
+        System.assertEquals(Datetime.newInstance(2020, 1, 1), path.getDatetime('$.aDatetime'));
+        System.assertEquals('hi', path.getString('$.text'));
+        System.assertEquals(1, ((ExampleObject) path.getDeserializedObject('$.exampleObject', ExampleObject.class)).myProp);
+    }
+
+    public class ExampleObject {
+        public Integer myProp;
+    }
 }


### PR DESCRIPTION
@renatoliveira I could also see a larger change being made to avoid the round-trip deserialization in `getDeserializedObject`, but I thought I'd at least include it for your review.